### PR TITLE
fix: use textContext for calculate line num height with escaped HTML characters

### DIFF
--- a/main.js
+++ b/main.js
@@ -328,7 +328,7 @@ function resizeNumWrapAndHLWrap(el, context) {
           oneLineText = view.editor.getLine(codeBlockInfo.lineStart + i + 1);
         } else {
         }
-        span.innerHTML = oneLineText || "0";
+        span.textContent = oneLineText || "0";
         codeBlockEl.appendChild(span);
         span.style.display = "block";
         let lineHeight = span.getBoundingClientRect().height + "px";

--- a/main.ts
+++ b/main.ts
@@ -468,7 +468,7 @@ function resizeNumWrapAndHLWrap(el: HTMLElement, context: MarkdownPostProcessorC
 				// let fileContentLines = fileContent.split(/\n/g)
 				// oneLineText = fileContentLines[cache.sections]
 			}
-			span.innerHTML = oneLineText || "0"
+			span.textContent = oneLineText || "0"
 
 			codeBlockEl.appendChild(span)
 			span.style.display = 'block'


### PR DESCRIPTION
use `Node.textContext` instead of `Element.innerHTML` 
for calculate line num height with escaped HTML characters.

Fix the issues:
https://github.com/stargrey/obsidian-better-codeblock/issues/12

When code block contains HTML characters,
the code-block-linenum span will be set wrong `height: 0px`, 
for example:

the Markdown code block in Obsidian:

````markdown
```html
<!-- Hello World -->
<div>
	Hello World
</div>
```
````

the rendered HTML result in Reading view:

```html
<span class="code-block-linenum-wrap">
	<span class="code-block-linenum" style="height: 0px;"></span>
	<span class="code-block-linenum" style="height: 0px;"></span>
	<span class="code-block-linenum" style="height: 24px;"></span>
	<span class="code-block-linenum" style="height: 0px;"></span>
</span>
```

Reference:

- `Note.textContent`
  <https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent>