### PR TITLE
refactor: use CSS class instead of fixed style in JavaScript for customize style with Obsidian's snippets

### DIFF
--- a/main.js
+++ b/main.js
@@ -59,7 +59,6 @@ var LINE_SPLIT_MARK = "\n";
 var titleRegExp = /TI:"([^"]*)"/i;
 var highLightLinesRegExp = /HL:"([^"]*)"/i;
 var foldRegExp = /"FOLD"/i;
-var CB_PADDING_TOP = "38px";
 var DEFAULT_SETTINGS = {
   substitutionTokenForSpace: void 0,
   titleBackgroundColor: "#00000020",
@@ -216,8 +215,6 @@ function createElement(tagName, defaultClassName) {
   return element;
 }
 function addCodeTitleWrapper(plugin, preElm, cbMeta) {
-  preElm.style.setProperty("position", "relative", "important");
-  preElm.style.setProperty("padding-top", CB_PADDING_TOP, "important");
   let wrapper = document.createElement("pre");
   if (cbMeta.isCollapse) {
     wrapper.setAttribute("closed", "");
@@ -260,7 +257,6 @@ function addLineNumber(plugin, cbMeta) {
   const { lineSize, pre, div } = cbMeta;
   div.classList.add("code-block-wrap");
   const lineNumber = createElement("span", "code-block-linenum-wrap");
-  lineNumber.style.top = CB_PADDING_TOP;
   Array.from({ length: lineSize }, (v, k) => k).forEach((i) => {
     const singleLine = createElement("span", "code-block-linenum");
     lineNumber.appendChild(singleLine);

--- a/main.js
+++ b/main.js
@@ -266,7 +266,7 @@ function addLineNumber(plugin, cbMeta) {
     lineNumber.appendChild(singleLine);
   });
   if (plugin.settings.showDividingLine) {
-    lineNumber.style.borderRight = "1px currentColor solid";
+    lineNumber.classList.add("code-block-linenum-wrap-show-dividing-line");
   }
   pre.appendChild(lineNumber);
   pre.classList.add("code-block-pre__has-linenum");

--- a/main.js
+++ b/main.js
@@ -59,7 +59,7 @@ var LINE_SPLIT_MARK = "\n";
 var titleRegExp = /TI:"([^"]*)"/i;
 var highLightLinesRegExp = /HL:"([^"]*)"/i;
 var foldRegExp = /"FOLD"/i;
-var CB_PADDING_TOP = "35px";
+var CB_PADDING_TOP = "38px";
 var DEFAULT_SETTINGS = {
   substitutionTokenForSpace: void 0,
   titleBackgroundColor: "#00000020",

--- a/main.ts
+++ b/main.ts
@@ -85,11 +85,11 @@ export default class BetterCodeBlock extends Plugin {
 	onunload () {
 		console.log('Unloading Better Code Block Plugin');
 	}
-	
+
 	async loadSettings() {
 		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
 	}
-	
+
 	async saveSettings() {
 		await this.saveData(this.settings);
 	}
@@ -97,17 +97,17 @@ export default class BetterCodeBlock extends Plugin {
 
 class BetterCodeBlockTab extends PluginSettingTab {
 	plugin: BetterCodeBlock;
-  
+
 	constructor(app: App, plugin: BetterCodeBlock) {
 	  super(app, plugin);
 	  this.plugin = plugin;
 	}
-  
+
 	display(): void {
 	  let { containerEl } = this;
-  
+
 	  containerEl.empty();
-	
+
 	  new Setting(containerEl)
 		.setName("Exclude language list")
 		.setDesc("Title and line numbers do not apply in these languages, separate by `,`")
@@ -118,7 +118,7 @@ class BetterCodeBlockTab extends PluginSettingTab {
 			await this.plugin.saveSettings();
 		})
 		)
-  
+
 	  new Setting(containerEl).setName("Font color of title").addText((tc) =>
 		tc
 		  .setPlaceholder("Enter a color")
@@ -128,7 +128,7 @@ class BetterCodeBlockTab extends PluginSettingTab {
 			await this.plugin.saveSettings();
 		  })
 	  );
-  
+
 	  new Setting(containerEl)
 		.setName("Background color of title")
 		.addText((tc) =>
@@ -155,7 +155,7 @@ class BetterCodeBlockTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 		.setName("Show line number")
-		.addToggle((tc) => 
+		.addToggle((tc) =>
 		tc.setValue(this.plugin.settings.showLineNumber)
 		.onChange(async(value) => {
 			this.plugin.settings.showLineNumber = value;
@@ -197,7 +197,7 @@ export async function BetterCodeBlocks(el: HTMLElement, context: MarkdownPostPro
 	if (plugin.settings.excludeLangs.some(eLangName => codeElm.classList.contains(`language-${eLangName}`))) {
 	  return
 	}
-	
+
 	codeElm.classList.forEach((value, key, parent) => {
 	  if (LANG_REG.test(value)) {
 		lang = value.replace('language-', '')
@@ -216,7 +216,7 @@ export async function BetterCodeBlocks(el: HTMLElement, context: MarkdownPostPro
 	if(codeBlock) {
 		let view = app.workspace.getActiveViewOfType(MarkdownView)
 		codeBlockFirstLine = view.editor.getLine(codeBlock.lineStart)
-	} else { 
+	} else {
 		let file = app.vault.getAbstractFileByPath(context.sourcePath)
 		let cache = app.metadataCache.getCache(context.sourcePath)
 		let fileContent = await app.vault.cachedRead(<TFile> file)
@@ -327,7 +327,7 @@ function addCodeTitle (plugin: BetterCodeBlock, preElm: HTMLElement, cbMeta: Cod
 	if(plugin.settings.titleFontColor) {
 		titleElm.style.setProperty("color", plugin.settings.titleFontColor, "important")
 	}
-	
+
 	if(plugin.settings.showLangNameInTopRight) {
 		let langName = document.createElement("div"); // 在右侧添加代码类型
 		let langNameString = cbMeta.langName
@@ -355,7 +355,7 @@ function addLineNumber (plugin: BetterCodeBlock, cbMeta: CodeBlockMeta) {
 	  // singleLine.style.lineHeight = lineHeight
 	  lineNumber.appendChild(singleLine)
 	})
-	
+
 	if(plugin.settings.showDividingLine) {
 		lineNumber.style.borderRight = "1px currentColor solid"
 	}
@@ -410,7 +410,7 @@ function addIconToTitle(plugin: BetterCodeBlock, preElm: HTMLElement, cbMeta: Co
 		iconWrap.appendChild(icon)
 		it.appendChild(iconWrap)
 	})
-	
+
 }
 
 // 在自动换行时对数字和高亮行重新设置高度
@@ -439,7 +439,7 @@ function resizeNumWrapAndHLWrap(el: HTMLElement, context: MarkdownPostProcessorC
 			return
 			// let file = app.vault.getAbstractFileByPath(context.sourcePath)
 			// let cache = app.metadataCache.getCache(context.sourcePath)
-	
+
 			// cache.sections?.forEach(async element => {
 			// 	if(element.type == "code") {
 			// 		lineStart = element.position.start.line
@@ -476,7 +476,7 @@ function resizeNumWrapAndHLWrap(el: HTMLElement, context: MarkdownPostProcessorC
 			let lineHeight = span.getBoundingClientRect().height + 'px' // 测量本行文字的高度
 
 			// console.log(lineHeight + '    ' + span.getBoundingClientRect().width);
-			
+
 			let numOneLine = numWrap? numWrap.childNodes[i] as HTMLElement : null
 			let hlOneLine = highWrap? highWrap.childNodes[i] as HTMLElement : null
 

--- a/main.ts
+++ b/main.ts
@@ -11,8 +11,6 @@ const titleRegExp = /TI:"([^"]*)"/i
 const highLightLinesRegExp = /HL:"([^"]*)"/i
 const foldRegExp = /"FOLD"/i
 
-const CB_PADDING_TOP = "38px" // 代码块上边距
-
 interface Settings {
 	substitutionTokenForSpace: string;
 	titleBackgroundColor: string;
@@ -288,9 +286,6 @@ function createElement (tagName: string, defaultClassName?: string) {
 }
 
 function addCodeTitleWrapper(plugin: BetterCodeBlock, preElm: HTMLElement, cbMeta: CodeBlockMeta) {
-	preElm.style.setProperty("position", "relative", "important");
-	preElm.style.setProperty("padding-top", CB_PADDING_TOP, "important");
-
 	let wrapper = document.createElement("pre")
 	if(cbMeta.isCollapse) {
 		wrapper.setAttribute("closed","")
@@ -348,7 +343,6 @@ function addLineNumber (plugin: BetterCodeBlock, cbMeta: CodeBlockMeta) {
 
 	// const { fontSize, lineHeight } = window.getComputedStyle(cbMeta.code)
 	const lineNumber = createElement('span', 'code-block-linenum-wrap')
-	lineNumber.style.top = CB_PADDING_TOP;
 	Array.from({ length: lineSize }, (v, k) => k).forEach(i => {
 	  const singleLine = createElement('span', 'code-block-linenum')
 	  // singleLine.style.fontSize = fontSize

--- a/main.ts
+++ b/main.ts
@@ -11,7 +11,7 @@ const titleRegExp = /TI:"([^"]*)"/i
 const highLightLinesRegExp = /HL:"([^"]*)"/i
 const foldRegExp = /"FOLD"/i
 
-const CB_PADDING_TOP = "35px" // 代码块上边距
+const CB_PADDING_TOP = "38px" // 代码块上边距
 
 interface Settings {
 	substitutionTokenForSpace: string;

--- a/main.ts
+++ b/main.ts
@@ -357,7 +357,7 @@ function addLineNumber (plugin: BetterCodeBlock, cbMeta: CodeBlockMeta) {
 	})
 
 	if(plugin.settings.showDividingLine) {
-		lineNumber.style.borderRight = "1px currentColor solid"
+		lineNumber.classList.add("code-block-linenum-wrap-show-dividing-line");
 	}
 
 	pre.appendChild(lineNumber)

--- a/styles.css
+++ b/styles.css
@@ -74,7 +74,7 @@ pre[class*=language-].code-block-pre__has-linenum {
 }
 
 .code-block-linenum-wrap-show-dividing-line {
-  border-right: 1px solid currentColor;
+  border-right: var(--divider-width) solid var(--divider-color);
 }
 
 /* 代码高亮 */

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,7 @@
+body {
+  --better-code-block-title-height: 38px;
+}
+
 .obsidian-embedded-code-title__code-block-title {
     position: absolute !important;
     top: 0;
@@ -19,9 +23,10 @@ pre[class*=language-] {
   font-size: var(--editor-font-size);
   line-height: 1.5em;
   position: relative !important;
-  padding-top: 38px !important;
+  padding-top: var(--better-code-block-title-height) !important;
   padding-bottom: 0px;
 }
+
 .obsidian-embedded-code-title__code-block-title + code[class*=language-]{
   padding: 0em 0em 0em 0em !important;
   /* padding-top: 0 !important; */
@@ -46,7 +51,7 @@ pre[class*=language-].code-block-pre__has-linenum {
 /* 代码行号 */
 .code-block-linenum-wrap {
   position: absolute;
-  top: 38px;
+  top: var(--better-code-block-title-height);
   left: 0px;
   min-width: 3em;
   font-size: var(--editor-font-size);
@@ -78,7 +83,7 @@ pre[class*=language-] .code-block-highlight-wrap {
   padding: 0;
   position: absolute;
   left: 0px;
-  top: 38px;
+  top: var(--better-code-block-title-height);
   width: 100%;
   height: 100%;
   background-color: transparent;
@@ -96,9 +101,9 @@ pre[class*=language-] .code-block-highlight-wrap span {
 :root {
   --admonition-details-icon: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M8.59 16.58L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.42z'/></svg>");
 }
-.obsidian-embedded-code-title__code-block-title{
-  line-height: 38px;
-  height: 38px !important;
+.obsidian-embedded-code-title__code-block-title {
+  line-height: var(--better-code-block-title-height);
+  height: var(--better-code-block-title-height) !important;
   color: currentColor !important;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -44,7 +44,7 @@ pre[class*=language-].code-block-pre__has-linenum {
 /* 代码行号 */
 .code-block-linenum-wrap {
   position: absolute;
-  /* top: 35px; */
+  /* top: 38px; */
   left: 0px;
   min-width: 3em;
   font-size: var(--editor-font-size);
@@ -72,7 +72,7 @@ pre[class*=language-] .code-block-highlight-wrap {
   padding: 0;
   position: absolute;
   left: 0px;
-  top: 35px;
+  top: 38px;
   width: 100%;
   height: 100%;
   background-color: transparent;
@@ -91,8 +91,8 @@ pre[class*=language-] .code-block-highlight-wrap span {
   --admonition-details-icon: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M8.59 16.58L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.42z'/></svg>");
 }
 .obsidian-embedded-code-title__code-block-title{
-  line-height: 35px;
-  height: 35px !important;
+  line-height: 38px;
+  height: 38px !important;
   color: currentColor !important;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -66,6 +66,10 @@ pre[class*=language-].code-block-pre__has-linenum {
   content: counter(line-num);
 }
 
+.code-block-linenum-wrap-show-dividing-line {
+  border-right: 1px solid currentColor;
+}
+
 /* 代码高亮 */
 pre[class*=language-] .code-block-highlight-wrap {
   margin: 0;

--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,3 @@
-
 .obsidian-embedded-code-title__code-block-title {
     position: absolute !important;
     top: 0;
@@ -52,7 +51,7 @@ pre[class*=language-].code-block-pre__has-linenum {
   line-height: 1.5em;
   counter-reset: line-num;
   text-align: center;
-  /* border-right: #999 2px solid; 行号与代码间分隔线 */ 
+  /* border-right: #999 2px solid; 行号与代码间分隔线 */
   user-select: none;
   pointer-events: none;
   background-color: transparent;

--- a/styles.css
+++ b/styles.css
@@ -18,6 +18,8 @@
 pre[class*=language-] {
   font-size: var(--editor-font-size);
   line-height: 1.5em;
+  position: relative !important;
+  padding-top: 38px !important;
   padding-bottom: 0px;
 }
 .obsidian-embedded-code-title__code-block-title + code[class*=language-]{
@@ -44,7 +46,7 @@ pre[class*=language-].code-block-pre__has-linenum {
 /* 代码行号 */
 .code-block-linenum-wrap {
   position: absolute;
-  /* top: 38px; */
+  top: 38px;
   left: 0px;
   min-width: 3em;
   font-size: var(--editor-font-size);


### PR DESCRIPTION
## Purpose

Use CSS class instead of fixed style in javascript,
so we will be available to customize style with Obsidian's snippets
(Ex: `.obsidian/snippets/my.css`)

> **My environment**:
>
> - Obsidian Version 1.0.3 (Installer 1.0.3)
> - Macbook (M1 / Apple Silicon)
> - macOS Monterey (12.6.1) 

### Changes

- [x] fix: line num dividing line is overlay to the code block title
    - Obsidian default style set `.markdown-rendered pre { min-height: 38px }` in `obsidian.md/app.css`, 
      but Better codeblock use `height: 35px` or `top: 35px`.
- [x] refactor: use CSS class instead of fixed style in javascript.
- [x] refactor: use CSS class instead of fixed style in javascript for show dividing line.
- [x] refactor: define CSS variable `--better-code-block-title-height: 38px` for code block title height. 
- [x] feat: use Obsidian built-in CSS variables `--divider-width` and `--divider-color` for dividing line.

### Demo

#### fix: line num dividing line

Before:

<img width="397" alt="SCR-20221112-voe" src="https://user-images.githubusercontent.com/5071526/201496447-4f641a71-b59a-48fd-9457-41f2dc83b550.png">

After:

<img width="396" alt="SCR-20221112-vpm" src="https://user-images.githubusercontent.com/5071526/201493371-3c2a7df5-f30e-4baf-915a-cf787736d342.png">

#### feat: use Obsidian built-in CSS variables `--divider-width` and `--divider-color` for dividing line.

Before:

<img width="754" alt="SCR-20221113-6gn" src="https://user-images.githubusercontent.com/5071526/201493776-193e1b56-2943-4442-83c9-aa5705dd2c3f.png">

After:

<img width="743" alt="SCR-20221113-6hq" src="https://user-images.githubusercontent.com/5071526/201493777-329d23bc-5afb-4194-8ee7-1dcb3945aad8.png">

#### Customize style with Obsidian's snippets

Add a CSS snippet and enable it in Obsidian:

```css
/**
 *  file: .obsidian/snippets/my.css
 */
.code-block-linenum-wrap-show-dividing-line {
    border-right: 2px solid var(--color-yellow);
}
```