### PR TITLE
Change insecure usage of "span.innerHTML" to "span.textContent"

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -468,7 +468,7 @@ function resizeNumWrapAndHLWrap(el: HTMLElement, context: MarkdownPostProcessorC
 				// let fileContentLines = fileContent.split(/\n/g)
 				// oneLineText = fileContentLines[cache.sections]
 			}
-			span.innerHTML = oneLineText || "0"
+			span.textContent = oneLineText || "0"
 
 			codeBlockEl.appendChild(span)
 			span.style.display = 'block'


### PR DESCRIPTION
The usage of span.innerHTML leads to the codeblock content being interpreted as HTML. This can lead to formatting issues when displaying the codeblock content and even to the execution of JavaScript via XSS.

Instead of innerHTML, textContent should be used, which parses the codeblock content as text to be displayed, as is the original intention.

This missing encoding issue was also raised before in these issues and pull requests:
https://github.com/stargrey/obsidian-better-codeblock/issues/12
https://github.com/stargrey/obsidian-better-codeblock/pull/15


